### PR TITLE
(#D02) Adiciona documentação referente às políticas do repositório

### DIFF
--- a/docs/planejamento/politicas_repositorio/politica_branches.md
+++ b/docs/planejamento/politicas_repositorio/politica_branches.md
@@ -1,0 +1,31 @@
+Padronização das branches no projeto. 
+
+## Semântica da Branch
+
+As branches devem seguir o seguinte padrão:
+
+### Formato:
+```
+#código_da_tarefa-descrição
+```
+
+#### Código da tarefa:
+- Referenciamento ao código da tarefa estabelecido no cronograma do trabalho
+
+#### Descrição:
+- Deve possuir no máximo 50 caracteres
+- Deve estar em letras minúsculas
+- As palavras devem estar separadas por -
+- Deve estar em pt-BR devido ao público alvo e aplicação escolhida
+
+*Exemplo de branch:*
+```
+#D02-politicas-do-repositorio"
+```
+
+## Histórico de Versões
+
+
+| Data       | Versão | Descrição                                 | Autor             |
+| :--------: | :----: | :----------:                              | :---------------: |
+| 13/04/2025 |  0.1   | Criação da política de branches           | [Ana Clara Borges](https://github.com/anabborges)|

--- a/docs/planejamento/politicas_repositorio/politica_branches.md
+++ b/docs/planejamento/politicas_repositorio/politica_branches.md
@@ -26,6 +26,6 @@ As branches devem seguir o seguinte padrão:
 ## Histórico de Versões
 
 
-| Data       | Versão | Descrição                                 | Autor             |
-| :--------: | :----: | :----------:                              | :---------------: |
-| 13/04/2025 |  0.1   | Criação da política de branches           | [Ana Clara Borges](https://github.com/anabborges)|
+| Data       | Versão | Descrição                                 | Autor             | Revisor           |
+| :--------: | :----: | :----------:                              | :---------------: | :---------------: |
+| 13/04/2025 |  0.1   | Criação da política de branches           | [Ana Clara Borges](https://github.com/anabborges)| [Gabriela Alves](https://github.com/gaubiela)|

--- a/docs/planejamento/politicas_repositorio/politica_commits.md
+++ b/docs/planejamento/politicas_repositorio/politica_commits.md
@@ -6,7 +6,7 @@ Os commits devem seguir o seguinte padrão:
 
 ### Formato:
 ```
-(#código da tarefa)<tipo>: descrição
+<tipo> (#código da tarefa): descrição
 ```
 
 #### Código da tarefa:

--- a/docs/planejamento/politicas_repositorio/politica_commits.md
+++ b/docs/planejamento/politicas_repositorio/politica_commits.md
@@ -30,7 +30,7 @@ Os commits devem seguir o seguinte padrão:
 
 *Exemplo de commit:*
 ```
-git commit -m "(#D02):memo:: adição da documentação da política de commits"
+git commit -m ":memo: (#D02): adição da documentação da política de commits"
 ```
 
 ## Histórico de Versões

--- a/docs/planejamento/politicas_repositorio/politica_commits.md
+++ b/docs/planejamento/politicas_repositorio/politica_commits.md
@@ -1,0 +1,41 @@
+Padronização dos commits no projeto. 
+
+## Semântica do Commit
+
+Os commits devem seguir o seguinte padrão:
+
+### Formato:
+```
+(#código da tarefa)<tipo>: descrição
+```
+
+#### Código da tarefa:
+- Referenciamento ao código da tarefa estabelecido no cronograma do trabalho
+
+#### Tipos:
+- :repeat: quando alguma alteração for feita
+- :cool: quando melhorias de formato/estrutura da documentação
+- :memo: quando adicionar/atualizar documentação
+- :bug: quando consertar um problema
+- :fire: quando remover código ou arquivos
+- :lipstick: quando adicionar estilizações
+- :bulb: quando adicionar ou alterar comentários
+- :heavy_plus_sign: quando adicionar uma dependência
+- :heavy_minus_sign: quando remover uma dependência
+
+#### Descrição:
+- Deve possuir no máximo 50 caracteres
+- Deve estar em letras minúsculas
+- Deve estar em pt-BR devido ao público alvo e aplicação escolhida
+
+*Exemplo de commit:*
+```
+git commit -m "(#D02):memo:: adição da documentação da política de commits"
+```
+
+## Histórico de Versões
+
+
+| Data       | Versão | Descrição                                 | Autor             |
+| :--------: | :----: | :----------:                              | :---------------: |
+| 13/04/2025 |  0.1   | Criação da política de commits           | [Ana Clara Borges](https://github.com/anabborges)|

--- a/docs/planejamento/politicas_repositorio/politica_commits.md
+++ b/docs/planejamento/politicas_repositorio/politica_commits.md
@@ -36,6 +36,6 @@ git commit -m ":memo: (#D02): adição da documentação da política de commits
 ## Histórico de Versões
 
 
-| Data       | Versão | Descrição                                 | Autor             |
-| :--------: | :----: | :----------:                              | :---------------: |
-| 13/04/2025 |  0.1   | Criação da política de commits           | [Ana Clara Borges](https://github.com/anabborges)|
+| Data       | Versão | Descrição                                 | Autor             | Revisor          |
+| :--------: | :----: | :----------:                              | :---------------: | :---------------:|
+| 13/04/2025 |  0.1   | Criação da política de commits           | [Ana Clara Borges](https://github.com/anabborges)| [Gabriela Alves](https://github.com/gaubiela)|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,8 @@ nav:
   - Planejamento:
       - Cronograma: planejamento/cronograma.md
       - Equipe: planejamento/equipe.md
+      - Políticas do Repositório: 
+        - Política de Commits: planejamento/politicas_repositorio/politica_commits.md
       - Heatmap: planejamento/heatmap.md
       - Lista de Apps Avaliados: planejamento/lista-de-apps-avaliados.md
       - Termo de Uso: planejamento/termo-de-uso.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Equipe: planejamento/equipe.md
       - Políticas do Repositório: 
         - Política de Commits: planejamento/politicas_repositorio/politica_commits.md
+        - Política de Branches: planejamento/politicas_repositorio/politica_branches.md
       - Heatmap: planejamento/heatmap.md
       - Lista de Apps Avaliados: planejamento/lista-de-apps-avaliados.md
       - Termo de Uso: planejamento/termo-de-uso.md


### PR DESCRIPTION
Esse pull request integra as atualizações referentes às políticas de commits e de branches, visando uma maior padronização e organização do repositório. As principais alterações incluem:

- Criação de uma pasta chamada "Políticas do repositório" que contém duas páginas: sendo uma para a explicação da política de commits e a outra para a explicação da política de branches.
- Adição da pasta e dos arquivos no menu de navegação do gitpages.